### PR TITLE
Fix issues with ownership and permission commands

### DIFF
--- a/wazuh-integrations/malwareBazaar/README.md
+++ b/wazuh-integrations/malwareBazaar/README.md
@@ -4,7 +4,7 @@ Documentation: https://bazaar.abuse.ch/api/#query_hash
 ## Usage
 Place the `custom-malwareBazaar` file on the `/var/ossec/integrations` directory and apply these permissions:
 ```
-chown wazuh:wazuh /var/ossec/integrations/custom-malwareBazaar 
+chown root:wazuh /var/ossec/integrations/custom-malwareBazaar 
 chmod 750 /var/ossec/integrations/custom-malwareBazaar
 ```
 

--- a/wazuh-integrations/malwareBazaar/README.md
+++ b/wazuh-integrations/malwareBazaar/README.md
@@ -4,8 +4,8 @@ Documentation: https://bazaar.abuse.ch/api/#query_hash
 ## Usage
 Place the `custom-malwareBazaar` file on the `/var/ossec/integrations` directory and apply these permissions:
 ```
-chown wazuh:wazuh /var/ossec/integrations/custom-malwarBazaar 
-chmod 750 /var/ossec/integrations/custom-malwarBazaar
+chown wazuh:wazuh /var/ossec/integrations/custom-malwareBazaar 
+chmod 750 /var/ossec/integrations/custom-malwareBazaar
 ```
 
 ## `ossec.conf` Configuration:


### PR DESCRIPTION
There was a typo in the filepath for both `chown` and `chmod` commands and if the file is writeable by the `wazuh` user the integrator will not execute it, which is why the file must be owned by the `root` user but the `wazuh` group (where it is only writeable by the user and has read+execute by the group).